### PR TITLE
Fix: progress text in stepper circle

### DIFF
--- a/src/components/BaseProgressCircle.vue
+++ b/src/components/BaseProgressCircle.vue
@@ -1,28 +1,29 @@
 <template>
-  <svg class="w-full h-full">
-    <!-- background circle -->
-    <circle
-      :stroke-width="strokeWidth"
-      class="text-inactive stroke-current"
-      :cx="centerX"
-      :cy="centerY"
-      :r="radius"
-      fill="transparent"
-    />
-    <!-- progress circle -->
-    <circle
-      :stroke-width="strokeWidth"
-      :class="progressClasses"
-      class="text-button stroke-current"
-      :cx="centerX"
-      :cy="centerY"
-      :r="radius"
-      fill="transparent"
-      :stroke-dasharray="strokeDashArray"
-    />
-    <!-- content inside circle -->
+  <div class="w-full h-full">
+    <svg class="w-full h-full text-divider">
+      <!-- background circle -->
+      <circle
+        :stroke-width="strokeWidth"
+        class="text-inactive stroke-current"
+        :cx="centerX"
+        :cy="centerY"
+        :r="radius"
+        fill="transparent"
+      />
+      <!-- progress circle -->
+      <circle
+        :stroke-width="strokeWidth"
+        :class="progressClasses"
+        class="text-button stroke-current"
+        :cx="centerX"
+        :cy="centerY"
+        :r="radius"
+        fill="transparent"
+        :stroke-dasharray="strokeDashArray"
+      />
+    </svg>
     <slot />
-  </svg>
+  </div>
 </template>
 
 <script>

--- a/src/components/BaseProgressCircle.vue
+++ b/src/components/BaseProgressCircle.vue
@@ -1,9 +1,9 @@
 <template>
-  <svg class="w-full h-full text-inactive stroke-current">
+  <svg class="w-full h-full">
     <!-- background circle -->
     <circle
       :stroke-width="strokeWidth"
-      class="text-gray-300"
+      class="text-inactive stroke-current"
       :cx="centerX"
       :cy="centerY"
       :r="radius"

--- a/src/components/BaseStepperCircle.vue
+++ b/src/components/BaseStepperCircle.vue
@@ -1,17 +1,10 @@
 <template>
   <div class="w-100 flex items-center h-20">
-    <div class="w-16 h-16">
-      <BaseProgressCircle :centerX="32" :centerY="32" :radius="30" :percentageProgress="percentageProgress">
-        <text
-          x="50%"
-          y="50%"
-          dominant-baseline="middle"
-          text-anchor="middle"
-          class="progress-circle--content text-black text-sm fill-current stroke-0"
-        >
-          {{ progressText }}
-        </text>
-      </BaseProgressCircle>
+    <div class="w-16 h-16 relative">
+      <BaseProgressCircle :centerX="32" :centerY="32" :radius="30" :percentageProgress="percentageProgress" />
+      <div class="text-xs absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2">
+        {{ progressText }}
+      </div>
     </div>
     <div class="flex-grow text-right flex items-end flex-col justify-center">
       <h3 class="text-primary mb-2 h2-mobile">{{ stepHeader(currentStep) }}</h3>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -71,6 +71,9 @@ module.exports = {
       },
       scale: {
         '-1': '-1'
+      },
+      inset: {
+        '1/2': '50%'
       }
     }
   },


### PR DESCRIPTION
This addresses Issue #26 

For more details on how this fix works, visit [PR #124](https://github.com/whynotearth/foodouken.com/pull/124) on Foodouken.

I had to reduce the text-size on the progress text because the text with `text-sm` applied did not fit in one line inside a `w-16 h-16` container.