### PR TITLE
Fix sticky header for the Email List page

### DIFF
--- a/src/views/EmailList.vue
+++ b/src/views/EmailList.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="">
     <BaseAppBarHeader
+      class="sticky top-0 bg-white"
       :title="titleHeader"
       :to-link="'/settings/email-lists'"
       :action="{ link: `${$route.params.groupName}/add`, label: 'Add New' }"


### PR DESCRIPTION
issue address [#44](https://github.com/whynotearth/Volkswagen-email-corperate-communications/issues/44)