### PR TITLE
107 hotfix change api of production

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [context.master.environment]
-  # VUE_APP_API_ENDPOINT = "https://api.whynot.earth"
+  VUE_APP_API_ENDPOINT = "https://api.whynot.earth"
 
 [context.staging.environment]
   VUE_APP_ROBOTS_NO_INDEX = "1"


### PR DESCRIPTION
Production currently is using stagingapi.whynot.earth (meredith staging)  
By applying this PR, it will connect to api.whynot.earth (meredith production)

#107 