### PR TITLE
uploader - change resizing configs

### DIFF
--- a/src/components/ImageUpload/ImageUpload.vue
+++ b/src/components/ImageUpload/ImageUpload.vue
@@ -11,8 +11,7 @@
         @opened="onUploaderOpened"
         :uploaderOptions="{
           maxFiles: 1,
-          maxImageWidth: 256,
-          maxImageHeight: 256
+          maxImageWidth: 160
         }"
       >
         <label class="bg-background m-1 block cursor-pointer" for="add-post-image-upload">


### PR DESCRIPTION
Set max width of 160px for images for now.  
We should send _image width_ to uploader and use it in email template because outlook does not support `max-width:100%`