### PR TITLE
#314 fix email preview in dashboard

### DIFF
--- a/src/components/TodayEmail.vue
+++ b/src/components/TodayEmail.vue
@@ -28,6 +28,9 @@ import { formatISODate, formatDate } from '@/helpers.js';
 export default {
   name: 'TodaysEmail',
   components: { BaseButton, BaseCounter, EmailPreview },
+  beforeMount() {
+    this.update_selected_articles();
+  },
   mounted() {
     this.fetch_daily_plan()
       .then(() => {
@@ -41,6 +44,9 @@ export default {
         this.debounced_preview();
       })
       .catch();
+  },
+  destroyed() {
+    this.update_selected_articles();
   },
   methods: {
     ...mapActions('email', ['debounced_preview', 'fetch_daily_plan', 'update_selected_articles']),


### PR DESCRIPTION
This is #314
For twice redirect to dashboard page email preview is 400
I used of beforeAmount & destroyed for fixing this issue,
In the edit blue delta & edit blue delta pages used of email preview but there not need clearing because those are depending with together and no problems