### PR TITLE
#396 add ripple effect directive

### DIFF
--- a/src/directives/ripple.js
+++ b/src/directives/ripple.js
@@ -1,0 +1,101 @@
+import { getPassiveEventConfig } from '../helpers';
+
+const SVG_NORM = 'http://www.w3.org/2000/svg';
+
+const EVENT_START = 'mousedown';
+const EVENT_END = 'mouseup';
+
+const TIMING = 300;
+
+const getPosition = el => {
+  const computedStyle = window.getComputedStyle(el);
+
+  if (computedStyle.position === 'static') {
+    return 'relative';
+  }
+
+  return computedStyle.position;
+};
+
+const createRippleGrow = (el, svg) => {
+  return event => {
+    const rect = el.getBoundingClientRect();
+
+    const x = event.offsetX;
+    const y = event.offsetY;
+    const w = el.offsetWidth;
+    const h = el.offsetHeight;
+
+    const offsetX = Math.abs(w / 2 - x);
+    const offsetY = Math.abs(h / 2 - y);
+    const deltaX = w / 2 + offsetX;
+    const deltaY = h / 2 + offsetY;
+    const scale = Math.sqrt(Math.pow(deltaX, 2) + Math.pow(deltaY, 2));
+
+    const g = document.createElementNS(SVG_NORM, 'g');
+    g.setAttribute('viewBox', '0 0 100 100');
+    g.setAttribute('width', '100');
+    g.setAttribute('height', '100');
+    g.style.transform = `translate(${x}px, ${y}px)`;
+    svg.appendChild(g);
+
+    const circle = document.createElementNS(SVG_NORM, 'circle');
+    circle.setAttribute('cx', '0');
+    circle.setAttribute('cy', '0');
+    circle.setAttribute('r', '1');
+    g.appendChild(circle);
+
+    el.appendChild(svg);
+
+    requestAnimationFrame(() => {
+      g.style.transform = `translate(${x}px, ${y}px) scale(${scale})`;
+    });
+  };
+};
+
+const createRippleFade = (el, svg, opacity = '') => {
+  return event => {
+    svg.style.opacity = '0';
+
+    setTimeout(() => {
+      while (svg.firstChild) {
+        svg.removeChild(svg.lastChild);
+      }
+      svg.classList.add('disable');
+      svg.style.opacity = '';
+      svg.classList.remove('disable');
+    }, TIMING);
+  };
+};
+
+const Ripple = {
+  inserted(el, { value: { fill, opacity } = {} }) {
+    el.style.position = getPosition(el);
+
+    const svg = document.createElementNS(SVG_NORM, 'svg');
+    svg.setAttribute('xmlns', SVG_NORM);
+    svg.setAttribute('focusable', 'false');
+    svg.classList.add('ripples');
+    el.appendChild(svg);
+
+    if (fill) {
+      svg.style.fill = fill;
+    }
+
+    if (opacity) {
+      svg.style.opacity = opacity;
+    }
+
+    el.rippleGrow = createRippleGrow(el, svg);
+    el.rippleFade = createRippleFade(el, svg, opacity);
+
+    el.addEventListener(EVENT_START, el.rippleGrow, getPassiveEventConfig());
+    el.addEventListener(EVENT_END, el.rippleFade, getPassiveEventConfig());
+  },
+  unbind(el) {
+    el.removeEventListener(EVENT_START, el.rippleGrow);
+    el.removeEventListener(EVENT_END, el.rippleFade);
+  }
+};
+
+export default Ripple;

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -28,3 +28,31 @@
 .fadeslower-leave-to {
   opacity: 0;
 }
+
+.ripples {
+  height: 100%;
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  z-index: -1;
+  opacity: 0.3;
+  transition-property: opacity;
+  transition-duration: 300ms;
+  transition-timing-function: linear;
+}
+
+.ripples.disable {
+  transition: none;
+}
+
+.ripples g {
+  transition-property: transform;
+  transition-duration: 500ms;
+  transition-timing-function: ease-in-out;
+}
+
+.rounded-full .ripples {
+  border-radius: 9999px;
+}


### PR DESCRIPTION
# Issue Being Addressed

#396

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

- [ ] Bug Fix
- [ ] Refactor
- [x] New Feature
- [ ] Update to Existing Feature
- [ ] Other (state below)

# Description

Add a directive to create a ripple effect on any component.

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.

In a template import the directive and use it on a component or element
```vue
<template>
  <div>
    <BaseButton v-ripple>First button</BaseButton>
    <BaseButton v-ripple="{ fill: '#fff' }">Second button</BaseButton>
    <BaseButton v-ripple="{ opacity: '.6' }">Third button</BaseButton>
  </div>
</template>

<script>
import ripple from '@/directives/ripple';

{
  // ...
  directive {
    ripple,
   },
  // ...
};
</script>
```

# Additional Context

Not importing globally the directive atm, letting choice to the devs when they want to use it or not.
The directive have two parameters:
- **fill** which allow to choose the color of the ripple
- **opacity** which is the opacity of the ripple effect
