### PR TITLE
dropdown - use dropdown of foodouken, fix layout everywhere dropdown …

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "qs": "^6.9.4",
     "register-service-worker": "1.6.2",
     "tailwindcss": "1.4.0",
+    "v-click-outside": "3.0.1",
     "validator": "13.0.0",
     "vue": "2.6.11",
     "vue-multiselect": "2.1.6",

--- a/src/assets/down.svg
+++ b/src/assets/down.svg
@@ -1,3 +1,3 @@
 <svg width="12" height="8" viewBox="0 0 12 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M1.41 0.590027L6 5.17003L10.59 0.590027L12 2.00003L6 8.00003L0 2.00003L1.41 0.590027Z" fill="black" fill-opacity="0.54"/>
+<path d="M1.41 0.590027L6 5.17003L10.59 0.590027L12 2.00003L6 8.00003L0 2.00003L1.41 0.590027Z" fill="currentColor"/>
 </svg>

--- a/src/components/ArticleAddStep2.vue
+++ b/src/components/ArticleAddStep2.vue
@@ -1,78 +1,76 @@
 <template>
   <div class="py-2 flex-grow">
-    <div class="container px-4 md:px-6 text-left">
-      <BaseInputText
-        v-if="isFieldVisible('headline')"
-        class="bg-surface mb-4"
-        v-model="$v.headline.$model"
-        :label="stringHeadlineByCategoryName"
-        :placeholder="stringHeadlineByCategoryName"
-        :error="$v.headline.$dirty && $v.headline.$invalid"
-        :model="$v.headline"
-      >
-        <span v-if="$v.headline.$dirty && !$v.headline.required" class="text-xs text-error pl-error-message">
-          {{ stringHeadlineByCategoryName }} is required
-        </span>
-        <span v-if="$v.headline.$dirty && !$v.headline.maxLength" class="text-xs text-error pl-error-message">
-          Max {{ $v.headline.$params.maxLength.max }} characters
-        </span>
-      </BaseInputText>
+    <BaseInputText
+      v-if="isFieldVisible('headline')"
+      class="bg-surface mb-4"
+      v-model="$v.headline.$model"
+      :label="stringHeadlineByCategoryName"
+      :placeholder="stringHeadlineByCategoryName"
+      :error="$v.headline.$dirty && $v.headline.$invalid"
+      :model="$v.headline"
+    >
+      <span v-if="$v.headline.$dirty && !$v.headline.required" class="text-xs text-error pl-error-message">
+        {{ stringHeadlineByCategoryName }} is required
+      </span>
+      <span v-if="$v.headline.$dirty && !$v.headline.maxLength" class="text-xs text-error pl-error-message">
+        Max {{ $v.headline.$params.maxLength.max }} characters
+      </span>
+    </BaseInputText>
 
-      <hr v-if="isFieldVisible('image')" class="my-4 bg-background border-black em-low -mx-4 sm:mx-0 mb-4" />
-      <ImageUpload v-if="isFieldVisible('image')" v-model="images" :defaultImages="images" />
+    <hr v-if="isFieldVisible('image')" class="my-4 bg-background border-black em-low -mx-4 sm:mx-0 mb-4" />
+    <ImageUpload v-if="isFieldVisible('image')" v-model="images" :defaultImages="images" />
 
-      <BaseEditor
-        v-if="isFieldVisible('excerpt') && !isImagesEmpty"
-        class="my-4 body-1-mobile bg-surface"
-        :error="$v.excerpt.$dirty && ($v.excerpt.$invalid || !$v.excerpt.required || !$v.excerpt.maxLength)"
-        placeholder="Excerpt"
-        v-model="$v.excerpt.$model"
-        :model="$v.excerpt"
-      >
-        <span v-if="$v.excerpt.$dirty && !$v.excerpt.required" class="text-xs text-error pl-error-message">
-          Excerpt is required
-        </span>
-        <span v-if="$v.excerpt.$dirty && !$v.excerpt.maxLength" class="text-xs text-error pl-error-message">
-          Max {{ $v.excerpt.$params.maxLength.max }} characters
-        </span>
-      </BaseEditor>
+    <BaseEditor
+      v-if="isFieldVisible('excerpt') && !isImagesEmpty"
+      class="my-4 body-1-mobile bg-surface"
+      :error="$v.excerpt.$dirty && ($v.excerpt.$invalid || !$v.excerpt.required || !$v.excerpt.maxLength)"
+      placeholder="Excerpt"
+      v-model="$v.excerpt.$model"
+      :model="$v.excerpt"
+    >
+      <span v-if="$v.excerpt.$dirty && !$v.excerpt.required" class="text-xs text-error pl-error-message">
+        Excerpt is required
+      </span>
+      <span v-if="$v.excerpt.$dirty && !$v.excerpt.maxLength" class="text-xs text-error pl-error-message">
+        Max {{ $v.excerpt.$params.maxLength.max }} characters
+      </span>
+    </BaseEditor>
 
-      <hr class="my-4 bg-background border-black em-low -mx-4 sm:mx-0 mb-4" />
+    <hr class="my-4 bg-background border-black em-low -mx-4 sm:mx-0 mb-4" />
 
-      <BaseEditor
-        class="mt-6 mb-4 body-1-mobile bg-surface"
-        :error="
-          $v.description.$dirty && ($v.description.$invalid || !$v.description.required || !$v.description.maxLength)
-        "
-        :placeholder="isAnswersCategory ? stringDescriptionByCategoryName : 'Put the content of your article here.'"
-        v-if="isFieldVisible('description')"
-        v-model="$v.description.$model"
-        :model="$v.description"
-      >
-        <span v-if="$v.description.$dirty && !$v.description.required" class="text-xs text-error pl-error-message">
-          {{ stringDescriptionByCategoryName }} is required
-        </span>
-        <span v-if="$v.description.$dirty && !$v.description.maxLength" class="text-xs text-error pl-error-message">
-          Max {{ $v.description.$params.maxLength.max }} characters
-        </span>
-      </BaseEditor>
+    <BaseEditor
+      class="mt-6 mb-4 body-1-mobile bg-surface"
+      :error="
+        $v.description.$dirty && ($v.description.$invalid || !$v.description.required || !$v.description.maxLength)
+      "
+      :placeholder="isAnswersCategory ? stringDescriptionByCategoryName : 'Put the content of your article here.'"
+      v-if="isFieldVisible('description')"
+      v-model="$v.description.$model"
+      :model="$v.description"
+    >
+      <span v-if="$v.description.$dirty && !$v.description.required" class="text-xs text-error pl-error-message">
+        {{ stringDescriptionByCategoryName }} is required
+      </span>
+      <span v-if="$v.description.$dirty && !$v.description.maxLength" class="text-xs text-error pl-error-message">
+        Max {{ $v.description.$params.maxLength.max }} characters
+      </span>
+    </BaseEditor>
 
-      <BaseInputText
-        v-if="isFieldVisible('eventDate')"
-        class="bg-surface mb-4"
-        v-model="$v.eventDate.$model"
-        label="Date/Time"
-        placeholder="20 March, 2020, 7:00 PM"
-        :error="$v.eventDate.$dirty && $v.eventDate.$invalid"
-      >
-        <span v-if="$v.eventDate.$dirty && !$v.eventDate.required" class="text-xs text-error pl-error-message">
-          Date/Time is required
-        </span>
-        <span v-if="$v.eventDate.$dirty && !$v.eventDate.mustBeDate" class="text-xs text-error pl-error-message">
-          Date/Time is invalid. Example: 2020-12-24 7:30 pm
-        </span>
-      </BaseInputText>
-    </div>
+    <BaseInputText
+      v-if="isFieldVisible('eventDate')"
+      class="bg-surface mb-4"
+      v-model="$v.eventDate.$model"
+      label="Date/Time"
+      placeholder="20 March, 2020, 7:00 PM"
+      :error="$v.eventDate.$dirty && $v.eventDate.$invalid"
+    >
+      <span v-if="$v.eventDate.$dirty && !$v.eventDate.required" class="text-xs text-error pl-error-message">
+        Date/Time is required
+      </span>
+      <span v-if="$v.eventDate.$dirty && !$v.eventDate.mustBeDate" class="text-xs text-error pl-error-message">
+        Date/Time is invalid. Example: 2020-12-24 7:30 pm
+      </span>
+    </BaseInputText>
   </div>
 </template>
 

--- a/src/components/ArticleAddStep3.vue
+++ b/src/components/ArticleAddStep3.vue
@@ -1,36 +1,34 @@
 <template>
   <div class="flex flex-col">
-    <div class="container px-4 md:px-6 select-none">
-      <BaseDropdown
-        class="relative bg-surface text-left"
-        placeholder="Schedule time"
-        :options="dates"
-        v-model="$v.date.$model"
-      >
-        <template #icon>
-          <Calendar class="inline-block align-baseline mr-4 h-5 w-5 -mb-0.5 pointer-events-none" />
-        </template>
-        <template #title="{ selectedOption }">
-          Schedule
-          <span v-if="dates.length === 0" class="text-gray-500">
-            No time slots!
-          </span>
-          <span v-else-if="selectedOption" class="ml-2 em-medium text-black">
-            {{ formatDate(selectedOption) }}
-          </span>
-        </template>
-        <template #option="{ option }">
-          <span>
-            {{ formatDate(option) }}
-          </span>
-        </template>
-      </BaseDropdown>
+    <BaseDropdown
+      class="relative bg-surface text-left"
+      placeholder="Schedule time"
+      :options="dates"
+      v-model="$v.date.$model"
+    >
+      <template #icon>
+        <Calendar class="inline-block align-baseline mr-4 h-5 w-5 -mb-0.5 pointer-events-none" />
+      </template>
+      <template #title="{ selectedOption }">
+        Schedule
+        <span v-if="dates.length === 0" class="text-gray-500">
+          No time slots!
+        </span>
+        <span v-else-if="selectedOption" class="ml-2 em-medium text-black">
+          {{ formatDate(selectedOption) }}
+        </span>
+      </template>
+      <template #option="{ option }">
+        <span>
+          {{ formatDate(option) }}
+        </span>
+      </template>
+    </BaseDropdown>
 
-      <div class="mt-8">
-        <p v-if="get_response_message.message" class="font-bold px-4 mb-4" :class="get_response_message.class">
-          {{ get_response_message.message }}
-        </p>
-      </div>
+    <div class="mt-8">
+      <p v-if="get_response_message.message" class="font-bold px-4 mb-4" :class="get_response_message.class">
+        {{ get_response_message.message }}
+      </p>
     </div>
   </div>
 </template>

--- a/src/components/BaseDropdown.vue
+++ b/src/components/BaseDropdown.vue
@@ -1,34 +1,34 @@
 <template>
-  <div>
+  <div class="mb-4 relative text-black text-opacity-84" v-click-outside="hideDropdown">
     <div
-      @click="showDropdown = !showDropdown"
-      class="flex flex-grow items-strech p-5 cursor-pointer rounded-lg shadow-1dp select-none"
-      :class="dropdownContainerClasses"
+      @click="toggleDropdown"
+      class="w-full mb-2 rounded shadow-1dp cursor-pointer flex items-center"
+      :class="[background, tight ? 'py-3 px-4 rounded' : 'p-5 rounded-lg']"
     >
-      <slot name="icon"></slot>
-      <span class="truncate" :class="selectedOption ? '' : 'text-gray-500'">
+      <div class="mr-4 h-5 w-5 pointer-events-none" v-if="$slots.icon">
+        <slot name="icon" />
+      </div>
+      <span class="inline-block flex-grow truncate text-black text-opacity-84">
         <slot name="title" :selectedOption="selectedOption">
           {{ selectedOption || placeholder }}
         </slot>
       </span>
-      <div class="flex flex-grow items-center justify-end">
-        <Down
-          class="transform inline-block pointer-events-none scale-x-1 text-gray"
-          :class="{ 'rotate-180': showDropdown }"
-        />
-      </div>
+      <IconDown
+        class="float-right pointer-events-none text-black flex-shrink-0 w-4 ml-4"
+        :class="{ 'transform rotate-180': dropdown }"
+      />
     </div>
     <div
-      v-if="showDropdown"
-      class="dropdown absolute right-0 left-0 bg-white mt-1 mx-2 md:mx-4 py-2 rounded-lg shadow-8dp overflow-x-hidden overflow-y-auto z-10"
-      :class="optionContainerClasses"
+      v-if="dropdown"
+      class="dropdown absolute right-0 left-0 z-20 narrow-scrollbars w-48 w-full shadow-8dp overflow-x-hidden overflow-y-auto"
+      :class="[background, tight ? 'rounded' : 'rounded-lg']"
     >
       <div
-        class="option p-4 first:rounded-t-lg last:rounded-b-lg cursor-pointer"
-        :class="{ active: selectedOption === option }"
         v-for="(option, index) in options"
         :key="index"
-        @click="updateDay(option)"
+        @click="updateValue(option)"
+        class="hover:bg-footer cursor-pointer"
+        :class="tight ? 'p-4 first:rounded-t last:rounded-b' : 'p-5 first:rounded-t-lg last:rounded-b-lg'"
       >
         <slot name="option" :option="option">{{ option }}</slot>
       </div>
@@ -37,15 +37,20 @@
 </template>
 
 <script>
-import Down from '@/assets/down.svg';
+import IconDown from '@/assets/down.svg';
+
 export default {
-  name: 'BaseDropdown',
-  components: { Down },
+  name: 'Dropdown',
+  components: { IconDown },
   model: {
     prop: 'selectedOption',
     event: 'updateSelectedOption'
   },
   props: {
+    icon: {
+      type: String,
+      default: null
+    },
     selectedOption: {
       type: [String, Date, Number, Object]
     },
@@ -59,24 +64,37 @@ export default {
       type: String,
       default: 'Select an option'
     },
-    optionContainerClasses: {
+    background: {
       type: String,
-      default: ''
+      default: 'bg-surface'
     },
-    dropdownContainerClasses: {
-      type: String,
-      default: ''
+    tight: {
+      type: Boolean,
+      default: false
     }
   },
   data() {
     return {
-      showDropdown: false
+      dropdown: false
     };
   },
   methods: {
-    updateDay(option) {
+    hideDropdown() {
+      this.dropdown = false;
+    },
+    showDropdown() {
+      this.dropdown = true;
+    },
+    toggleDropdown() {
+      if (this.dropdown) {
+        this.hideDropdown();
+      } else {
+        this.showDropdown();
+      }
+    },
+    updateValue(option) {
       this.$emit('updateSelectedOption', option);
-      this.showDropdown = false;
+      this.hideDropdown();
     }
   }
 };
@@ -84,33 +102,6 @@ export default {
 
 <style scoped>
 .dropdown {
-  max-height: 15rem;
-}
-.rotate-180 {
-  transform: rotate(180deg);
-}
-.dropdown::-webkit-scrollbar {
-  width: 3px;
-  padding: 2px 0;
-}
-.dropdown::-webkit-scrollbar-track {
-  background: #ddd;
-  box-shadow: none;
-}
-.dropdown::-webkit-scrollbar-thumb {
-  background: #666;
-  outline: transparent;
-}
-.option:hover,
-.active {
-  background: rgba(3, 179, 249, 0.12);
-}
-
-.dropdown-top-auto {
-  @apply top-auto !important;
-}
-
-.dropdown-border-0 {
-  @apply border-b-0 !important;
+  max-height: 13rem;
 }
 </style>

--- a/src/components/LayoutFixedFooter.vue
+++ b/src/components/LayoutFixedFooter.vue
@@ -7,7 +7,7 @@
           <slot v-if="isVisible" name="content" />
         </transition>
       </div>
-      <div class="fixed bottom-0 w-full"><slot name="footer" /></div>
+      <div class="fixed bottom-0 w-full z-30"><slot name="footer" /></div>
     </div>
   </div>
 </template>

--- a/src/main.js
+++ b/src/main.js
@@ -7,8 +7,10 @@ import store from './store';
 import './styles/tailwind.css';
 import configureModerator from './store/store-moderator';
 import Vuelidate from 'vuelidate';
+import vClickOutside from 'v-click-outside';
 
 Vue.use(Vuelidate);
+Vue.use(vClickOutside);
 
 Vue.config.productionTip = false;
 

--- a/src/views/ArticleAdd.vue
+++ b/src/views/ArticleAdd.vue
@@ -7,47 +7,49 @@
       />
     </template>
     <template #content>
-      <div class="min-h-full relative bg-background">
-        <BaseDropdown
-          class="relative bg-surface text-left container px-0 md:px-6"
-          :optionContainerClasses="'dropdown-top-auto'"
-          :dropdownContainerClasses="'dropdown-border-0'"
-          placeholder="Choose Type"
-          :options="get_categories.filter(category => category.slug !== 'community')"
-          v-model="$v.selected_category.$model"
-        >
-          <template #title="{ selectedOption }">
-            <div v-if="!get_categories.filter(category => category.slug !== 'community')">No option found</div>
-            <div v-if="selectedOption && selectedOption.name" class="flex items-center">
-              <div class="w-12 h-12">
-                <img class="p-2" :src="selectedOption.image" alt="" />
+      <div class="container px-4 md:px-6 text-left pt-6 mb-40">
+        <div class="mb-6">
+          <BaseDropdown
+            class="bg-surface"
+            :optionContainerClasses="'dropdown-top-auto'"
+            :dropdownContainerClasses="'dropdown-border-0'"
+            placeholder="Choose Type"
+            :options="get_categories.filter(category => category.slug !== 'community')"
+            v-model="$v.selected_category.$model"
+          >
+            <template #title="{ selectedOption }">
+              <div v-if="!get_categories.filter(category => category.slug !== 'community')">No option found</div>
+              <div v-if="selectedOption && selectedOption.name" class="flex items-center">
+                <div class="w-12 h-12">
+                  <img class="p-2" :src="selectedOption.image" alt="" />
+                </div>
+                <div class="flex-auto">
+                  <div class="w-full body-1-mobile text-black text-opacity-84">{{ selectedOption.name }}</div>
+                  <div class="w-full text-xs text-black em-disabled">{{ selectedOption.description }}</div>
+                </div>
               </div>
-              <div class="flex-auto">
-                <div class="w-full body-1-mobile">{{ selectedOption.name }}</div>
-                <div class="w-full text-xs text-black em-disabled">{{ selectedOption.description }}</div>
+              <div v-else>
+                No category selected
               </div>
-            </div>
-            <div v-else>
-              No category selected
-            </div>
-          </template>
-          <template #option="{ option }">
-            <a @click.prevent="selected_category = option" href="#" class="flex items-center">
-              <div class="w-12 h-12">
-                <img class="p-2" :src="option.image" alt="" />
-              </div>
-              <div class="flex-auto">
-                <div class="w-full body-1-mobile">{{ option.name }}</div>
-                <div class="w-full text-xs text-black em-disabled">{{ option.description }}</div>
-              </div>
-            </a>
-          </template>
-        </BaseDropdown>
+            </template>
+            <template #option="{ option }">
+              <a @click.prevent="selected_category = option" href="#" class="flex items-center">
+                <div class="w-12 h-12">
+                  <img class="p-2" :src="option.image" alt="" />
+                </div>
+                <div class="flex-auto">
+                  <div class="w-full body-1-mobile text-black text-opacity-84">{{ option.name }}</div>
+                  <div class="w-full text-xs text-black em-disabled">{{ option.description }}</div>
+                </div>
+              </a>
+            </template>
+          </BaseDropdown>
+        </div>
         <div v-if="$v.selected_category.$model && $v.selected_category.$model.name">
           <ArticleAddStep2 ref="articleAdd" :error="validationError" />
           <ArticleAddStep3 ref="articleAdd2" :error="validationError" />
-          <div class="my-6">
-            <BaseButton @selectButton="submit" class="w-64" bgType="secondary"> Save </BaseButton>
+          <div class="my-6 justify-center flex">
+            <BaseButton @selectButton="submit" class="w-64 mx-auto" bgType="secondary"> Save </BaseButton>
           </div>
         </div>
         <div class="mt-4" v-else>Please select category to continue</div>

--- a/src/views/ArticleListsItem.vue
+++ b/src/views/ArticleListsItem.vue
@@ -4,43 +4,45 @@
       <BaseAppBarHeader :title="get_headline" :to-link="{ name: 'ArticleLists' }" />
     </template>
     <template #content>
-      <div v-if="selectedArticle && selectedArticle.id" class="min-h-full relative bg-background">
-        <BaseDropdown
-          class="relative bg-surface text-left container px-0 md:px-6"
-          :optionContainerClasses="'dropdown-top-auto'"
-          :dropdownContainerClasses="'dropdown-border-0'"
-          placeholder="Choose Type"
-          :options="get_categories.filter(category => category.slug !== 'community')"
-          v-model="$v.selected_category.$model"
-        >
-          <template #title="{ selectedOption }">
-            <div v-if="!get_categories.filter(category => category.slug !== 'community')">No option found</div>
-            <div v-if="selectedOption && selectedOption.name" class="flex items-center">
-              <div class="w-12 h-12">
-                <img class="p-2" :src="selectedOption.image" alt="" />
-              </div>
-              <div class="flex-auto">
-                <div class="w-full body-1-mobile">{{ selectedOption.name }}</div>
-                <div class="w-full text-xs text-black em-disabled">{{ selectedOption.description }}</div>
-              </div>
-            </div>
-            <div v-else>
-              No category selected
-            </div>
-          </template>
-          <template #option="{ option }">
-            <a @click.prevent="selected_category = option" href="#" class="flex items-center">
-              <div class="w-12 h-12">
-                <img class="p-2" :src="option.image" alt="" />
-              </div>
-              <div class="flex-auto">
-                <div class="w-full body-1-mobile">{{ option.name }}</div>
-                <div class="w-full text-xs text-black em-disabled">{{ option.description }}</div>
-              </div>
-            </a>
-          </template>
-        </BaseDropdown>
-        <div class="container px-4 md:px-6 text-left">
+      <div class="container px-0 md:px-6 pt-6 mb-40 text-left">
+        <div v-if="selectedArticle && selectedArticle.id" class="min-h-full relative bg-background">
+          <div class="mb-6">
+            <BaseDropdown
+              :optionContainerClasses="'dropdown-top-auto'"
+              :dropdownContainerClasses="'dropdown-border-0'"
+              placeholder="Choose Type"
+              :options="get_categories.filter(category => category.slug !== 'community')"
+              v-model="$v.selected_category.$model"
+            >
+              <template #title="{ selectedOption }">
+                <div v-if="!get_categories.filter(category => category.slug !== 'community')">No option found</div>
+                <div v-if="selectedOption && selectedOption.name" class="flex items-center">
+                  <div class="w-12 h-12">
+                    <img class="p-2" :src="selectedOption.image" alt="" />
+                  </div>
+                  <div class="flex-auto">
+                    <div class="w-full body-1-mobile">{{ selectedOption.name }}</div>
+                    <div class="w-full text-xs text-black em-disabled">{{ selectedOption.description }}</div>
+                  </div>
+                </div>
+                <div v-else>
+                  No category selected
+                </div>
+              </template>
+              <template #option="{ option }">
+                <a @click.prevent="selected_category = option" href="#" class="flex items-center">
+                  <div class="w-12 h-12">
+                    <img class="p-2" :src="option.image" alt="" />
+                  </div>
+                  <div class="flex-auto">
+                    <div class="w-full body-1-mobile">{{ option.name }}</div>
+                    <div class="w-full text-xs text-black em-disabled">{{ option.description }}</div>
+                  </div>
+                </a>
+              </template>
+            </BaseDropdown>
+          </div>
+
           <BaseInputText
             v-if="isFieldRequired('headline')"
             class="bg-surface mb-4"
@@ -120,6 +122,9 @@
             :options="dates"
             v-model="$v.date.$model"
           >
+            <template #icon>
+              <Calendar />
+            </template>
             <template #title="{ selectedOption }">
               Schedule
               <span v-if="dates.length === 0" class="text-gray-500">
@@ -176,6 +181,7 @@ import BaseEditor from '@/components/Editor/BaseEditor.vue';
 import BaseDropdown from '@/components/BaseDropdown';
 import ImageUpload from '@/components/ImageUpload/ImageUpload.vue';
 import LayoutFixedScrollable from '@/components/LayoutFixedScrollable.vue';
+import Calendar from '@/assets/calendar.svg';
 import { mapGetters, mapMutations, mapActions } from 'vuex';
 import { required, decimal, maxLength, requiredIf } from 'vuelidate/lib/validators';
 import { mustBeDate } from '@/validations.js';
@@ -190,7 +196,8 @@ export default {
     BaseInputText,
     BaseEditor,
     BaseDropdown,
-    ImageUpload
+    ImageUpload,
+    Calendar
   },
   validations() {
     return {

--- a/src/views/BlueDeltaSettings.vue
+++ b/src/views/BlueDeltaSettings.vue
@@ -4,104 +4,102 @@
       <BaseAppBarHeader title="Blue Delta Settings" :to-link="{ name: 'Settings' }"></BaseAppBarHeader>
     </template>
     <template #content>
-      <div class="relative">
-        <div class="container px-0 md:px-6">
-          <div class="flex justify-between text-left py-6 px-4 mt-2">
-            <div class="">Send email automatically</div>
-            <BaseToggleSwitch :value="enableAutoSend" @toggleSwitch="toggleSwitch" />
-          </div>
-          <hr />
-          <template v-if="enableAutoSend">
-            <div class="text-left py-6 px-4 pb-0">
-              <p class="mb-6">
-                By default, Blue Delta will automatically send each day according to the below details. You can change
-                these manually for each individual Blue Delta
-                <router-link class="text-secondary underline" :to="{ name: 'JumpStartLists' }">here</router-link>.
-              </p>
-            </div>
-
-            <div
-              class="px-4 bg-white pb-0 text-left"
-              :class="[
-                {
-                  'is-query-empty': to_query === '',
-                  'is-filled': !$v.distributionGroups.$invalid,
-                  error: $v.distributionGroups.$error
-                },
-                $v.distributionGroups.$error
-                  ? 'text-red-600 border-red-600 pl-error-message'
-                  : 'text-gray-500 border-gray-600'
-              ]"
-            >
-              <label
-                class="multiselect--material-label absolute"
-                v-if="!$v.distributionGroups.$invalid"
-                for="distributionGroups"
-              >
-                Default Distribution List:
-              </label>
-              <Multiselect
-                id="distributionGroups"
-                v-model="$v.distributionGroups.$model"
-                :placeholder="$v.distributionGroups.$invalid ? 'Distribution List' : ''"
-                :options="get_recipients_available"
-                :multiple="true"
-                :hide-selected="true"
-                :show-labels="false"
-                @search-change="onToSearchChange"
-              >
-                <template v-slot:noResult>Nothing found</template>
-                <template v-slot:noOptions>No options available</template>
-              </Multiselect>
-              <span v-if="$v.distributionGroups.$error" class="text-xs text-error text-left pl-error-message">
-                Distribution Groups is required
-              </span>
-            </div>
-
-            <div class="flex relative my-4">
-              <div class="flex-auto">
-                <BaseDropdown
-                  class="text-left border-t"
-                  placeholder="Schedule time"
-                  :options="time_slots"
-                  v-model="$v.sendTime.$model"
-                >
-                  <template #title="{ selectedOption }">
-                    <span v-if="time_slots.length === 0" class="text-gray-500">
-                      No time slots!
-                    </span>
-                    <span v-else-if="selectedOption">
-                      Schedule
-                      <span class="ml-2 em-medium">
-                        {{ millisecondToTime(selectedOption) }}
-                      </span>
-                    </span>
-                  </template>
-                  <template #option="{ option }">
-                    <span>
-                      {{ millisecondToTime(option) }}
-                    </span>
-                  </template>
-                </BaseDropdown>
-              </div>
-              <p v-if="$v.sendTime.$error" class="text-xs text-error pl-error-message">
-                Please select time.
-              </p>
-            </div>
-            <p v-if="get_response_message.message" class="font-bold px-4 mb-4" :class="get_response_message.class">
-              {{ get_response_message.message }}
-            </p>
-
-            <div class="px-12 max-w-sm mx-auto pt-8">
-              <BaseButton
-                @selectButton="updateSettings"
-                class="block bg-secondary w-full hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full focus:outline-none focus:shadow-outline transition duration-100 ease-in-out transition-all label-mobile mb-6"
-              >
-                SAVE
-              </BaseButton>
-            </div>
-          </template>
+      <div class="container px-4 md:px-6 text-left pt-6">
+        <div class="flex justify-between text-left py-6 mt-2">
+          <div class="">Send email automatically</div>
+          <BaseToggleSwitch :value="enableAutoSend" @toggleSwitch="toggleSwitch" />
         </div>
+        <hr />
+        <template v-if="enableAutoSend">
+          <div class="text-left py-6 pb-0">
+            <p class="mb-6">
+              By default, Blue Delta will automatically send each day according to the below details. You can change
+              these manually for each individual Blue Delta
+              <router-link class="text-secondary underline" :to="{ name: 'JumpStartLists' }">here</router-link>.
+            </p>
+          </div>
+
+          <div
+            class="bg-white pb-0 text-left"
+            :class="[
+              {
+                'is-query-empty': to_query === '',
+                'is-filled': !$v.distributionGroups.$invalid,
+                error: $v.distributionGroups.$error
+              },
+              $v.distributionGroups.$error
+                ? 'text-red-600 border-red-600 pl-error-message'
+                : 'text-gray-500 border-gray-600'
+            ]"
+          >
+            <label
+              class="multiselect--material-label absolute"
+              v-if="!$v.distributionGroups.$invalid"
+              for="distributionGroups"
+            >
+              Default Distribution List:
+            </label>
+            <Multiselect
+              id="distributionGroups"
+              v-model="$v.distributionGroups.$model"
+              :placeholder="$v.distributionGroups.$invalid ? 'Distribution List' : ''"
+              :options="get_recipients_available"
+              :multiple="true"
+              :hide-selected="true"
+              :show-labels="false"
+              @search-change="onToSearchChange"
+            >
+              <template v-slot:noResult>Nothing found</template>
+              <template v-slot:noOptions>No options available</template>
+            </Multiselect>
+            <span v-if="$v.distributionGroups.$error" class="text-xs text-error text-left pl-error-message">
+              Distribution Groups is required
+            </span>
+          </div>
+
+          <div class="flex relative my-4">
+            <div class="flex-auto">
+              <BaseDropdown
+                class="text-left border-t"
+                placeholder="Schedule time"
+                :options="time_slots"
+                v-model="$v.sendTime.$model"
+              >
+                <template #title="{ selectedOption }">
+                  <span v-if="time_slots.length === 0" class="text-gray-500">
+                    No time slots!
+                  </span>
+                  <span v-else-if="selectedOption">
+                    Schedule
+                    <span class="ml-2 em-medium">
+                      {{ millisecondToTime(selectedOption) }}
+                    </span>
+                  </span>
+                </template>
+                <template #option="{ option }">
+                  <span>
+                    {{ millisecondToTime(option) }}
+                  </span>
+                </template>
+              </BaseDropdown>
+            </div>
+            <p v-if="$v.sendTime.$error" class="text-xs text-error pl-error-message">
+              Please select time.
+            </p>
+          </div>
+          <p v-if="get_response_message.message" class="font-bold mb-4" :class="get_response_message.class">
+            {{ get_response_message.message }}
+          </p>
+
+          <div class="px-12 max-w-sm mx-auto pt-8">
+            <BaseButton
+              @selectButton="updateSettings"
+              class="block bg-secondary w-full hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-full focus:outline-none focus:shadow-outline transition duration-100 ease-in-out transition-all label-mobile mb-6"
+            >
+              SAVE
+            </BaseButton>
+          </div>
+        </template>
       </div>
     </template>
 

--- a/src/views/StatsOverviewJumpstarts.vue
+++ b/src/views/StatsOverviewJumpstarts.vue
@@ -14,7 +14,7 @@
             v-model="date"
           >
             <template #icon>
-              <Calendar class="inline-block align-baseline mr-4 h-5 w-5 -mb-0.5 pointer-events-none" />
+              <Calendar />
             </template>
             <template #title="{ selectedOption }">
               <span v-if="dates.length === 0" class="text-gray-500">

--- a/yarn.lock
+++ b/yarn.lock
@@ -9314,6 +9314,11 @@ uuid@^3.3.2, uuid@^3.4.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+v-click-outside@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v-click-outside/-/v-click-outside-3.0.1.tgz#95870c199726069f4eda7eb5781ade62526dd269"
+  integrity sha512-FITcAM0R3JEPUSGiO7hfhKDODZHkOQTk/FyI9mwxNcz6LbMbJhABhjevLI5VsU00PRksloQx8vmpFIqlAfX6nw==
+
 v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"


### PR DESCRIPTION
# Issue Being Addressed

#409 

# Type of PR

Put an `x` in the brackets for the type(s) of PR this is. You may tick more than one.

- [x] Bug Fix
- [ ] Refactor
- [x] New Feature
- [ ] Update to Existing Feature
- [ ] Other (state below)

# Description

_For Bug Fixes:_ Dropdowns are similar to foodouken's dropdown but there was some issues in that so I had to update it (background and position of dropdown elements).  
Also there was layout issues on pages that was using dropdown like blue-delta-edit and settings-blue-delta, issue was wrong usage of container and it's fixed now.

_For New Feature_: A package added for click outside of dropdown (was used in foodouken's dropdown). So when dropdown is open and you click outside it, it should close the list now.

# How to Test/Reproduce

Provide steps on how one can test your changes here. e.g.

1. Go to any page that has a dropdown
2. Check styles, page side paddings and check if there is any horizontal scrollbar both in mobile and desktop.

# Screenshots/casts

If applicable, include any relevant screenshot or screencasts of your changes.
![image](https://user-images.githubusercontent.com/510242/84637603-221c4300-af0b-11ea-8dd7-93c8b879ae42.png)


