### PR TITLE
stats overview - fix date range cache

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -213,10 +213,14 @@ export function statsOverviewGenerateDateRangesAvailable() {
   ];
 }
 
-export function statsOverviewDateRangeParamsGenerator({ range, isAllTime }) {
+export function statsOverviewDateRangeParamsGenerator(dateRange) {
+  const range = dateRange.value;
+  const isAllTime = dateRange.id === 'all_time';
+
   const fromDate = formatISO(new Date(range[0]), { representation: 'date' });
   const toDate = formatISO(new Date(range[1]), { representation: 'date' });
   const toDateMinusOneDay = formatISO(addDays(new Date(range[1]), -1), { representation: 'date' });
+
   return {
     filenameDate: isAllTime ? 'all-time' : `${fromDate}--${toDateMinusOneDay}`,
     params: {

--- a/src/store/modules/distributionGroup.js
+++ b/src/store/modules/distributionGroup.js
@@ -12,11 +12,7 @@ export default {
     emails: [],
     selectedEmail: {},
     email: '',
-    stats_overview: null,
-    stats_overview_date_range: {
-      text: '',
-      value: [] // ['2020-06-06', '2020-06-13']
-    }
+    stats_overview: null
   },
   mutations: {
     updateEmailLists(state, payload) {
@@ -36,9 +32,6 @@ export default {
     },
     update_stats_overview(state, payload) {
       state.stats_overview = payload;
-    },
-    update_stats_overview_date_range(state, payload) {
-      state.stats_overview_date_range = payload;
     }
   },
   actions: {
@@ -171,7 +164,6 @@ export default {
     email: state => {
       return state.email;
     },
-    get_stats_overview: state => state.stats_overview,
-    get_stats_overview_date_range: state => state.stats_overview_date_range
+    get_stats_overview: state => state.stats_overview
   }
 };

--- a/src/store/modules/email.js
+++ b/src/store/modules/email.js
@@ -34,10 +34,6 @@ export default {
     available_articles: [],
     stats: [],
     stats_overview: null,
-    stats_overview_date_range: {
-      text: '',
-      value: [] // ['2020-06-06', '2020-06-13']
-    },
     stat: {}
   },
   getters: {
@@ -58,7 +54,6 @@ export default {
     get_available_articles: state => state.available_articles,
     get_stats: state => state.stats,
     get_stats_overview: state => state.stats_overview,
-    get_stats_overview_date_range: state => state.stats_overview_date_range,
     get_stat: state => state.stat
   },
   actions: {
@@ -182,9 +177,6 @@ export default {
     },
     update_stats_overview(state, payload) {
       state.stats_overview = payload;
-    },
-    update_stats_overview_date_range(state, payload) {
-      state.stats_overview_date_range = payload;
     }
   }
 };

--- a/src/store/modules/memo.js
+++ b/src/store/modules/memo.js
@@ -29,10 +29,6 @@ export default {
     },
     stats: [],
     stats_overview: null,
-    stats_overview_date_range: {
-      text: '',
-      value: [] // ['2020-06-06', '2020-06-13']
-    },
     stat: {}
   },
   mutations: {
@@ -65,9 +61,6 @@ export default {
     },
     update_stats_overview(state, payload) {
       state.stats_overview = payload;
-    },
-    update_stats_overview_date_range(state, payload) {
-      state.stats_overview_date_range = payload;
     }
   },
   actions: {
@@ -103,7 +96,6 @@ export default {
     get_response_message: state => state.response_message,
     get_stats: state => state.stats,
     get_stat: state => state.stat,
-    get_stats_overview: state => state.stats_overview,
-    get_stats_overview_date_range: state => state.stats_overview_date_range
+    get_stats_overview: state => state.stats_overview
   }
 };

--- a/src/views/StatsOverviewDistributionGroup.vue
+++ b/src/views/StatsOverviewDistributionGroup.vue
@@ -11,7 +11,7 @@
             class="relative bg-surface text-left mb-6"
             placeholder="Schedule time"
             :options="dateRangesAvailable"
-            v-model="stats_overview_date_range"
+            v-model="dateRange"
             @updateSelectedOption="fetchStatsOverview"
           >
             <template #icon>
@@ -35,7 +35,7 @@
             <ChartsStatsOverview
               v-if="get_stats_overview"
               :stats_overview="get_stats_overview"
-              :stats_overview_date_range="stats_overview_date_range"
+              :stats_overview_date_range="dateRange"
             >
               <template #title
                 ><span class="block text-center">{{ distributionGroupName }}</span></template
@@ -100,6 +100,8 @@ import {
 } from '@/helpers';
 import { addDays, addYears, formatISO } from 'date-fns';
 
+const dateRangesAvailable = statsOverviewGenerateDateRangesAvailable();
+
 export default {
   name: 'StatsOverviewDistributionGroup',
   components: {
@@ -112,49 +114,32 @@ export default {
     Calendar,
     Stat
   },
+  data: () => {
+    return {
+      dateRange: dateRangesAvailable.find(item => item.id === '7d_ago')
+    };
+  },
   created() {
     this.fetchStatsOverview();
   },
   computed: {
-    ...mapGetters('distributionGroup', ['get_stats_overview_date_range', 'get_stats_overview']),
+    ...mapGetters('distributionGroup', ['get_stats_overview']),
     distributionGroupName() {
       return this.$route.params.groupName;
     },
-    stats_overview_date_range: {
-      get() {
-        const current = this.get_stats_overview_date_range;
-        // default value
-        if (!current.value.length > 0) {
-          const last7days = this.dateRangesAvailable[0];
-          return last7days;
-        }
-        return current;
-      },
-      set(value) {
-        this.update_stats_overview_date_range(value);
-      }
-    },
-
     dateRangesAvailable() {
-      return this.statsOverviewGenerateDateRangesAvailable();
-    },
-
-    dateRangeParamsGenerator() {
-      return statsOverviewDateRangeParamsGenerator({
-        range: this.stats_overview_date_range.value,
-        isAllTime: this.get_stats_overview_date_range.id === 'all_time'
-      });
+      return dateRangesAvailable;
     }
   },
 
   methods: {
-    ...mapMutations('distributionGroup', ['update_stats_overview_date_range']),
     ...mapActions('distributionGroup', ['fetch_stats_overview', 'export_stats_overview', 'delete_group']),
 
-    statsOverviewGenerateDateRangesAvailable,
-
     exportStatsOverview() {
-      this.export_stats_overview(this.dateRangeParamsGenerator);
+      this.export_stats_overview(statsOverviewDateRangeParamsGenerator(this.dateRange));
+    },
+    fetchStatsOverview() {
+      this.fetch_stats_overview(statsOverviewDateRangeParamsGenerator(this.dateRange));
     },
 
     async deleteList() {
@@ -162,10 +147,6 @@ export default {
         await this.delete_group(this.distributionGroupName);
         showOverlayAndRedirect({ title: 'Success!', route: { name: 'EmailLists' } });
       }
-    },
-
-    fetchStatsOverview() {
-      this.fetch_stats_overview(this.dateRangeParamsGenerator);
     }
   }
 };

--- a/src/views/StatsOverviewJumpstarts.vue
+++ b/src/views/StatsOverviewJumpstarts.vue
@@ -12,7 +12,7 @@
             class="relative bg-surface text-left mb-6"
             placeholder="Schedule time"
             :options="dateRangesAvailable"
-            v-model="stats_overview_date_range"
+            v-model="dateRange"
             @updateSelectedOption="fetchStatsOverview"
           >
             <template #icon>
@@ -36,7 +36,7 @@
             <ChartsStatsOverview
               v-if="get_stats_overview"
               :stats_overview="get_stats_overview"
-              :stats_overview_date_range="stats_overview_date_range"
+              :stats_overview_date_range="dateRange"
             >
               <template #title><span class="block text-center">JumpStart Overview</span></template>
             </ChartsStatsOverview>
@@ -54,7 +54,7 @@
             <ChartTagUsage
               v-if="get_stats_overview"
               :stats_overview="get_stats_overview"
-              :stats_overview_date_range="stats_overview_date_range"
+              :stats_overview_date_range="dateRange"
             />
           </div>
         </div>
@@ -99,6 +99,8 @@ import { colors, opacity } from '@/constants/theme.js';
 import { formatDate, statsOverviewGenerateDateRangesAvailable, statsOverviewDateRangeParamsGenerator } from '@/helpers';
 import { addDays, addYears, formatISO } from 'date-fns';
 
+const dateRangesAvailable = statsOverviewGenerateDateRangesAvailable();
+
 export default {
   name: 'StatsOverviewJumpStarts',
   components: {
@@ -112,50 +114,29 @@ export default {
     Calendar,
     Stat
   },
+  data: () => {
+    return {
+      dateRange: dateRangesAvailable.find(item => item.id === '7d_ago')
+    };
+  },
   created() {
     this.fetchStatsOverview();
   },
   computed: {
-    ...mapGetters('email', ['get_stats_overview_date_range', 'get_stats_overview']),
-    stats_overview_date_range: {
-      get() {
-        const current = this.get_stats_overview_date_range;
-        // default value
-        if (!current.value.length > 0) {
-          const last7days = this.dateRangesAvailable[0];
-          return last7days;
-        }
-        return current;
-      },
-      set(value) {
-        this.update_stats_overview_date_range(value);
-      }
-    },
-
+    ...mapGetters('email', ['get_stats_overview']),
     dateRangesAvailable() {
-      return this.statsOverviewGenerateDateRangesAvailable();
-    },
-
-    dateRangeParamsGenerator() {
-      return statsOverviewDateRangeParamsGenerator({
-        range: this.stats_overview_date_range.value,
-        isAllTime: this.get_stats_overview_date_range.id === 'all_time'
-      });
+      return dateRangesAvailable;
     }
   },
 
   methods: {
-    ...mapMutations('email', ['update_stats_overview_date_range']),
     ...mapActions('email', ['fetch_stats_overview', 'export_stats_overview']),
 
-    statsOverviewGenerateDateRangesAvailable,
-
     exportStatsOverview() {
-      this.export_stats_overview(this.dateRangeParamsGenerator);
+      this.export_stats_overview(statsOverviewDateRangeParamsGenerator(this.dateRange));
     },
-
     fetchStatsOverview() {
-      this.fetch_stats_overview(this.dateRangeParamsGenerator);
+      this.fetch_stats_overview(statsOverviewDateRangeParamsGenerator(this.dateRange));
     }
   }
 };

--- a/src/views/StatsOverviewMemos.vue
+++ b/src/views/StatsOverviewMemos.vue
@@ -11,7 +11,7 @@
             class="relative bg-surface text-left mb-6"
             placeholder="Schedule time"
             :options="dateRangesAvailable"
-            v-model="stats_overview_date_range"
+            v-model="dateRange"
             @updateSelectedOption="fetchStatsOverview"
           >
             <template #icon>
@@ -35,7 +35,7 @@
             <ChartsStatsOverview
               v-if="get_stats_overview"
               :stats_overview="get_stats_overview"
-              :stats_overview_date_range="stats_overview_date_range"
+              :stats_overview_date_range="dateRange"
             >
               <template #title><span class="block text-center">Memo Overview</span></template>
             </ChartsStatsOverview>
@@ -81,6 +81,8 @@ import { colors, opacity } from '@/constants/theme.js';
 import { formatDate, statsOverviewGenerateDateRangesAvailable, statsOverviewDateRangeParamsGenerator } from '@/helpers';
 import { addDays, addYears, formatISO } from 'date-fns';
 
+const dateRangesAvailable = statsOverviewGenerateDateRangesAvailable();
+
 export default {
   name: 'StatsOverviewMemos',
   components: {
@@ -93,50 +95,28 @@ export default {
     Calendar,
     Stat
   },
+  data: () => {
+    return {
+      dateRange: dateRangesAvailable.find(item => item.id === '7d_ago')
+    };
+  },
   created() {
     this.fetchStatsOverview();
   },
   computed: {
-    ...mapGetters('memo', ['get_stats_overview_date_range', 'get_stats_overview']),
-    stats_overview_date_range: {
-      get() {
-        const current = this.get_stats_overview_date_range;
-        // default value
-        if (!current.value.length > 0) {
-          const last7days = this.dateRangesAvailable[0];
-          return last7days;
-        }
-        return current;
-      },
-      set(value) {
-        this.update_stats_overview_date_range(value);
-      }
-    },
-
+    ...mapGetters('memo', ['get_stats_overview']),
     dateRangesAvailable() {
-      return this.statsOverviewGenerateDateRangesAvailable();
-    },
-
-    dateRangeParamsGenerator() {
-      return statsOverviewDateRangeParamsGenerator({
-        range: this.stats_overview_date_range.value,
-        isAllTime: this.get_stats_overview_date_range.id === 'all_time'
-      });
+      return dateRangesAvailable;
     }
   },
 
   methods: {
-    ...mapMutations('memo', ['update_stats_overview_date_range']),
     ...mapActions('memo', ['fetch_stats_overview', 'export_stats_overview']),
-
-    statsOverviewGenerateDateRangesAvailable,
-
     exportStatsOverview() {
-      this.export_stats_overview(this.dateRangeParamsGenerator);
+      this.export_stats_overview(statsOverviewDateRangeParamsGenerator(this.dateRange));
     },
-
     fetchStatsOverview() {
-      this.fetch_stats_overview(this.dateRangeParamsGenerator);
+      this.fetch_stats_overview(statsOverviewDateRangeParamsGenerator(this.dateRange));
     }
   }
 };


### PR DESCRIPTION
# Issue Being Addressed

#447 

# Type of PR

- [x] Bug Fix
- [ ] Refactor
- [ ] New Feature
- [ ] Update to Existing Feature
- [ ] Other (state below)

# Description

_For Bug Fixes:_ If you had visited stats overview page yesterday, today the date range picker would fetch the same range as yesterday. With this PR date range picker won't be cached anymore.

Affected pages: all stats overview pages

- [x] jumpstart stats overview
- [x] memo stats overview
- [x] distribution groups stats overview
- [ ] individual jumpstart stats overview #413 

